### PR TITLE
Add missing start paragraph tag

### DIFF
--- a/view/zf/auth/receive-code.phtml
+++ b/view/zf/auth/receive-code.phtml
@@ -2,7 +2,7 @@
 if ($this->code) {
     printf("<h2>The authentication code is %s</h2>", $this->code);
     printf("<p>Use this code to request an access token.</p>");
-    printf("For instance, using <a href=\"https://github.com/jkbr/httpie\">HTTPie</a>:</p> ");
+    printf("<p>For instance, using <a href=\"https://github.com/jkbr/httpie\">HTTPie</a>:</p> ");
     printf(
         "<p>http POST %s grant_type=authorization_code code=%s redirect_uri=%s client_id=testclient client_secret=testpass</p>",
         $this->serverUrl('/oauth'),


### PR DESCRIPTION
Add missing start paragraph tag to the example link so that the HTML is
well-structured again

<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This addresses issue #2, where the `receive-code.phtml` file had a missing starting paragraph tag when showing the example instruction for requesting an access token using HTTPie.
