### PR TITLE
Fix BC break in BcryptTrait

### DIFF
--- a/src/Adapter/BcryptTrait.php
+++ b/src/Adapter/BcryptTrait.php
@@ -40,8 +40,12 @@ trait BcryptTrait
 
     /**
      * Check password using bcrypt
+     *
+     * @param array<string, string> $user
+     * @param string $password
+     * @return bool
      */
-    protected function checkPassword(string $user, string $password): bool
+    protected function checkPassword($user, $password)
     {
         return $this->verifyHash($password, $user['password']);
     }

--- a/src/Adapter/MongoAdapter.php
+++ b/src/Adapter/MongoAdapter.php
@@ -49,7 +49,7 @@ class MongoAdapter extends OAuth2Mongo
     /**
      * Check password using bcrypt
      *
-     * @param string $user
+     * @param array<string, string> $user
      * @param string $password
      * @return bool
      */

--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -46,7 +46,7 @@ class PdoAdapter extends OAuth2Pdo
     /**
      * Check password using bcrypt
      *
-     * @param string $user
+     * @param array<array-key, mixed> $user
      * @param string $password
      * @return bool
      */


### PR DESCRIPTION
Since `BcryptTrait` is a public API, changes to its method signatures can have a BC impact.
In particular, the change to `checkPassword` for 1.7.0 was incorrect, as `$user` is an array, and because the signature is intended to match those in the oauth2-server sources.

Additionally, some of the parameter annotations in oauth2-server class extensions were incorrect, and have been updated.

Fixes #36
